### PR TITLE
Fix removed Decoder.loop_count public property (unbreak OpenSesame media player)

### DIFF
--- a/mediadecoder/decoder.py
+++ b/mediadecoder/decoder.py
@@ -119,6 +119,11 @@ class Decoder(object):
         return self._clock.time
 
     @property
+    def loop_count(self):
+        """Indicates how often the clip has looped."""
+        return self._loop_count
+
+    @property
     def loop(self):
         """Indicates whether the playback should loop."""
         return self._loop


### PR DESCRIPTION
In 2c3f6a1d57c6591be018d49978908d4fa47b0340, `Decoder.loop_count` was changed to `Decoder._loop_count`. This has changed the public API, and broken the OpenSesame `media_player_mpy` plugin. This PR reimplements `loop_count` as a property. Could you package and release this to unbreak the OpenSesame media player?